### PR TITLE
Add support for self-service

### DIFF
--- a/demo/signals.py
+++ b/demo/signals.py
@@ -1,0 +1,15 @@
+import logging
+from typing import cast
+
+from django.dispatch import receiver
+
+from visitors.models import Visitor
+from visitors.signals import self_service_visitor_created
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(self_service_visitor_created)
+def send_visitor_notification(sender: object, **kwargs: object) -> None:
+    visitor = cast(Visitor, kwargs["visitor"])
+    logger.info(f"Sending visitor pass to: {visitor.email}")

--- a/demo/templates/visitors/self_service_request.html
+++ b/demo/templates/visitors/self_service_request.html
@@ -1,0 +1,36 @@
+<html>
+    <head>
+        <style>
+            input {
+                display: list-item;
+                margin-bottom: 10px;
+            }
+        </style>
+    </head>
+    <body>
+        <div style="max-width: 800px">
+            <h1>Access Denied</h1>
+            <h2>Self-Service demonstration</h2>
+            <p>
+                You have been denied access to a page that requires a Visitor Pass. This page is
+                marked as 'self-service', which means that you can grant yourself access by filling
+                in the details below.
+            </p>
+            {% if DEBUG %}
+            <p>
+                Running in DEBUG mode this demo does not send out email notifications once the
+                visitor pass is created, but will instead display a success page. In production you
+                should handle the `self_service_visitor_created` signal to send out the email.
+            </p>
+            <p>
+                NB in production the visitor pass will be emailed to you, as we require confirmation
+                that you are the owner of the email address.
+            </p>
+            {% endif %}
+            <form action="." method="post">
+                {% csrf_token %} {{ form }}
+                <input type="submit" value="Submit" />
+            </form>
+        </div>
+    </body>
+</html>

--- a/demo/templates/visitors/self_service_request.html
+++ b/demo/templates/visitors/self_service_request.html
@@ -17,15 +17,15 @@
                 in the details below.
             </p>
             {% if DEBUG %}
-            <p>
-                Running in DEBUG mode this demo does not send out email notifications once the
-                visitor pass is created, but will instead display a success page. In production you
-                should handle the `self_service_visitor_created` signal to send out the email.
-            </p>
-            <p>
-                NB in production the visitor pass will be emailed to you, as we require confirmation
-                that you are the owner of the email address.
-            </p>
+                <p>
+                    Running in DEBUG mode this demo does not send out email notifications once the
+                    visitor pass is created, but will instead display a success page. In production you
+                    should handle the `self_service_visitor_created` signal to send out the email.
+                </p>
+                <p>
+                    NB in production the visitor pass will be emailed to you, as we require confirmation
+                    that you are the owner of the email address.
+                </p>
             {% endif %}
             <form action="." method="post">
                 {% csrf_token %} {{ form }}

--- a/demo/templates/visitors/self_service_success.html
+++ b/demo/templates/visitors/self_service_success.html
@@ -1,0 +1,15 @@
+<html>
+    <body>
+        <h1>Django Visitor Pass</h1>
+        <h2>Self-Service demonstration</h2>
+        <p>A new visitor pass has been created for you.</p>
+        <p>
+            In a production environment you should connect to the `self_service_visitor_created`
+            signal and send the visitor pass to end user.
+        </p>
+        <p>
+            Link:
+            <a href="{{ visitor.context.redirect_to }}?vuid={{ visitor.uuid }}">{{ visitor.context.redirect_to }}?vuid={{ visitor.uuid }}</a>
+        </p>
+    </body>
+</html>

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 import demo.views
+from visitors import urls as visitor_urls
 
 admin.autodiscover()
 
@@ -10,5 +11,6 @@ urlpatterns = [
     path("foo/", demo.views.foo, name="foo"),
     path("bar/", demo.views.bar, name="bar"),
     path("logout/", demo.views.logout, name="logout"),
+    path("visitors/", include(visitor_urls, namespace="visitors")),
     path("", demo.views.index, name="index"),
 ]

--- a/demo/views.py
+++ b/demo/views.py
@@ -17,6 +17,12 @@ def foo(request: HttpRequest) -> HttpResponse:
     return HttpResponse("OK")
 
 
+# Test view that supports self-service
+@user_is_visitor(scope="bar", self_service=True)
+def bar(request: HttpRequest) -> HttpResponse:
+    return render(request, template_name="bar.html")
+
+
 # Deactivate any current visitor token - this is analagous
 # to "logging out" an authenticated user.
 def logout(request: HttpRequest) -> HttpResponse:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+from django.contrib.auth.models import User
+
+from visitors.models import Visitor
+
+
+@pytest.fixture
+def visitor() -> Visitor:
+    return Visitor.objects.create(email="fred@example.com", scope="foo")
+
+
+@pytest.fixture
+def temp_visitor() -> Visitor:
+    return Visitor.objects.create_temp_visitor(scope="foo", redirect_to="/foo")
+
+
+@pytest.fixture
+def user() -> User:
+    return User.objects.create(username="Fred")

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -12,16 +12,6 @@ from visitors.decorators import user_is_visitor
 from visitors.models import Visitor, VisitorLog
 
 
-@pytest.fixture
-def visitor() -> Visitor:
-    return Visitor.objects.create(email="fred@example.com", scope="foo")
-
-
-@pytest.fixture
-def user() -> User:
-    return User.objects.create(username="Fred")
-
-
 @pytest.mark.django_db
 class TestDecorators:
     def _request(

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -6,6 +6,7 @@ from django.contrib.sessions.backends.base import SessionBase
 from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory
+from django.urls import reverse
 
 from visitors.decorators import user_is_visitor
 from visitors.models import Visitor, VisitorLog
@@ -119,3 +120,19 @@ class TestDecorators:
 
         _ = view(request)
         assert VisitorLog.objects.count() == 0
+
+    def test_self_service_redirect(self):
+        request = self._request(visitor=None)
+
+        @user_is_visitor(scope="foo", self_service=True)
+        def view(request: HttpRequest) -> HttpResponse:
+            return HttpResponse("OK")
+
+        response = view(request)
+        assert response.status_code == 302
+        visitor = Visitor.objects.get()
+        assert visitor.is_self_service
+        assert not visitor.is_active
+        assert response.url == reverse(
+            "visitors:self-service", kwargs={"visitor_uuid": visitor.uuid}
+        )

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from visitors.forms import SelfServiceForm
+
+
+class TestSelfServiceForm:
+    @pytest.mark.parametrize(
+        "first_name,last_name,email,vuid,is_valid",
+        [
+            ("", "", "", None, False),
+            ("John", "", "", None, False),
+            ("John", "Doe", "", None, False),
+            ("John", "Doe", "john@doe.com", None, False),
+            ("John", "Doe", "john@doe.com", uuid4(), True),
+            ("John", "Doe", "john.doe@example.com", uuid4(), False),
+        ],
+    )
+    def test_form(self, first_name, last_name, email, vuid, is_valid):
+        form = SelfServiceForm(
+            {
+                "first_name": first_name,
+                "last_name": last_name,
+                "email": email,
+                "vuid": vuid,
+            }
+        )
+        assert form.is_valid() == is_valid

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+from django.http import Http404
+from django.test import RequestFactory
+from django.urls import reverse
+from django.utils.timezone import now as tz_now
+
+from visitors.exceptions import InvalidVisitorPass
+from visitors.models import Visitor
+from visitors.views import SelfService
+
+
+@pytest.mark.django_db
+class TestSelfService:
+    @mock.patch("visitors.views.render")
+    @pytest.mark.parametrize(
+        "is_active,has_expired,error",
+        [
+            (True, True, InvalidVisitorPass),
+            (True, False, InvalidVisitorPass),
+            (False, True, InvalidVisitorPass),
+            (False, False, None),
+        ],
+    )
+    def test_get(
+        self,
+        mock_render,
+        rf: RequestFactory,
+        visitor: Visitor,
+        is_active: bool,
+        has_expired: bool,
+        error: Exception,
+    ) -> None:
+        request = rf.get("/")
+        request.visitor = visitor
+        visitor.is_active = is_active
+        if has_expired:
+            visitor.expires_at = tz_now() - timedelta(seconds=1)
+        visitor.save()
+        view = SelfService()
+        assert visitor.has_expired == has_expired
+        assert visitor.is_active == is_active
+        if error:
+            with pytest.raises(error):
+                view.get(request, visitor.uuid)
+        else:
+            resp = view.get(request, visitor.uuid)
+            assert resp.status_code == mock_render.return_value.status_code
+            mock_render.assert_called_once_with(
+                request,
+                template_name="visitors/self_service_request.html",
+                context={"visitor": visitor, "form": mock.ANY},
+            )
+
+    def test_post_404(self, rf: RequestFactory) -> None:
+        request = rf.post("/")
+        view = SelfService()
+        with pytest.raises(Http404):
+            view.post(request, visitor_uuid=uuid4())
+
+    def test_post_valid(self, rf: RequestFactory, temp_visitor: Visitor) -> None:
+        assert not temp_visitor.is_active
+        request = rf.post(
+            "/",
+            {
+                "vuid": temp_visitor.uuid,
+                "first_name": "Henry",
+                "last_name": "Root",
+                "email": "henry@altavista.com",
+            },
+        )
+        request.visitor = temp_visitor
+        view = SelfService()
+        resp = view.post(request, visitor_uuid=temp_visitor.uuid)
+        assert resp.status_code == 302
+        temp_visitor.refresh_from_db()
+        assert temp_visitor.is_active
+        assert temp_visitor.first_name == "Henry"
+        assert temp_visitor.last_name == "Root"
+        assert temp_visitor.email == "henry@altavista.com"
+        assert resp.url == reverse(
+            "visitors:self-service-success",
+            kwargs={"visitor_uuid": temp_visitor.uuid},
+        )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,11 +1,9 @@
 from django.contrib import admin
-from django.urls import path
-
-from . import views
+from django.urls import include, path
 
 admin.autodiscover()
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("foo/", views.foo),
+    path("visitors", include("visitors.urls")),
 ]

--- a/visitors/apps.py
+++ b/visitors/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class VisitorsConfig(AppConfig):
     name = "visitors"
-    verbose_name = "Visitors"
+    verbose_name = "Visitor passes"

--- a/visitors/decorators.py
+++ b/visitors/decorators.py
@@ -134,11 +134,8 @@ def redirect_to_self_service(request: HttpRequest, scope: str) -> HttpResponseRe
     # create an inactive token for the time being. This will be used by
     # the auto-enroll view. The user fills in their name and email, which
     # overwrites the blank values here, and sets the token to be active.
-    visitor = Visitor.objects.create(
-        email=Visitor.DEFAULT_SELF_SERVICE_EMAIL,
-        scope=scope,
-        is_active=False,
-        context={"self-service": True, "redirect_to": request.get_full_path()},
+    visitor = Visitor.objects.create_temp_visitor(
+        scope=scope, redirect_to=request.get_full_path()
     )
     return HttpResponseRedirect(
         reverse(

--- a/visitors/decorators.py
+++ b/visitors/decorators.py
@@ -5,16 +5,21 @@ import logging
 from typing import Any, Callable
 
 from django.conf import settings
-from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse
+from django.http.response import HttpResponseRedirect
+from django.urls import reverse
 from django.utils.translation import gettext as _
 
-from .models import VisitorLog
+from .exceptions import VisitorAccessDenied
+from .models import Visitor, VisitorLog
 
 logger = logging.getLogger(__name__)
 
 # universal scope - essentially unscoped access
 SCOPE_ANY = "*"
+
+# for typing
+BypassFunc = Callable[[HttpRequest], bool]
 
 
 def is_visitor(user: settings.AUTH_USER_MODEL) -> bool:
@@ -47,11 +52,10 @@ def _get_request_arg(*args: Any) -> HttpRequest | None:
 
 def user_is_visitor(  # noqa: C901
     view_func: Callable | None = None,
-    # scope must be a kwarg as view_func is one, but we want to disallow
-    # an empty str - so use as default and fail if not overwritten.
     scope: str = "",
-    bypass_func: Callable[[HttpRequest], bool] | None = None,
+    bypass_func: BypassFunc | None = None,
     log_visit: bool = True,
+    self_service: bool = False,
 ) -> Callable:
     """
     Decorate view functions that supports Visitor access.
@@ -67,13 +71,22 @@ def user_is_visitor(  # noqa: C901
     The 'log_visit' arg can be used to override the default logging - if this
     is too noisy, for instance.
 
+    If 'self_service' is True, then instead of a straight PermissionDenied error
+    we raise VisitorAccessDenied, passing along the scope. This is then picked
+    up in the middleware, and the user redirected to a page where they can
+    enter their details and effectively invite themselves. Caveat emptor.
+
     """
     if not scope:
         raise ValueError("Decorator scope cannot be empty.")
 
     if view_func is None:
         return functools.partial(
-            user_is_visitor, scope=scope, bypass_func=bypass_func, log_visit=log_visit
+            user_is_visitor,
+            scope=scope,
+            bypass_func=bypass_func,
+            log_visit=log_visit,
+            self_service=self_service,
         )
 
     @functools.wraps(view_func)
@@ -94,18 +107,42 @@ def user_is_visitor(  # noqa: C901
         if bypass_func and bypass_func(request):
             return view_func(*args, **kwargs)
 
-        # Do we have a visitor?
-        if not request.user.is_visitor:
-            raise PermissionDenied(_("Visitor access denied"))
+        if not is_valid_request(request, scope):
+            if self_service:
+                return redirect_to_self_service(request, scope)
+            raise VisitorAccessDenied(_("Visitor access denied"), scope)
 
-        # Check the function scope matches (or is "*")
-        if scope in (SCOPE_ANY, request.visitor.scope):
-            response = view_func(*args, **kwargs)
-            if log_visit:
-                VisitorLog.objects.create_log(request, response.status_code)
-            return response
-
-        # We have a visitor with the wrong scope
-        raise PermissionDenied(_("Visitor access denied (invalid scope)."))
+        response = view_func(*args, **kwargs)
+        if log_visit:
+            VisitorLog.objects.create_log(request, response.status_code)
+        return response
 
     return inner
+
+
+def is_valid_request(request: HttpRequest, scope: str) -> bool:
+    """Return True if the request matches the scope."""
+    if not request.user.is_visitor:
+        return False
+    if scope == SCOPE_ANY:
+        return True
+    return request.visitor.scope == scope
+
+
+def redirect_to_self_service(request: HttpRequest, scope: str) -> HttpResponseRedirect:
+    """Create inactive Visitor token and redirect to enable self-service."""
+    # create an inactive token for the time being. This will be used by
+    # the auto-enroll view. The user fills in their name and email, which
+    # overwrites the blank values here, and sets the token to be active.
+    visitor = Visitor.objects.create(
+        email=Visitor.DEFAULT_SELF_SERVICE_EMAIL,
+        scope=scope,
+        is_active=False,
+        context={"self-service": True, "redirect_to": request.get_full_path()},
+    )
+    return HttpResponseRedirect(
+        reverse(
+            "visitors:self-service",
+            kwargs={"visitor_uuid": visitor.uuid},
+        )
+    )

--- a/visitors/forms.py
+++ b/visitors/forms.py
@@ -1,0 +1,20 @@
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
+
+
+class SelfServiceForm(forms.Form):
+    """Form for capturing user info."""
+
+    first_name = forms.CharField(max_length=150)
+    last_name = forms.CharField(max_length=150)
+    email = forms.EmailField(required=True)
+    vuid = forms.CharField(widget=forms.HiddenInput())
+
+    def clean_email(self) -> str:
+        email = self.cleaned_data["email"]
+        if email.endswith("example.com"):
+            raise ValidationError(
+                _("Invalid email - you cannot use the example.com domain")
+            )
+        return email

--- a/visitors/models.py
+++ b/visitors/models.py
@@ -11,17 +11,15 @@ from django.http.request import HttpRequest
 from django.utils.timezone import now as tz_now
 from django.utils.translation import gettext_lazy as _lazy
 
+from .exceptions import InvalidVisitorPass
 from .settings import VISITOR_QUERYSTRING_KEY, VISITOR_TOKEN_EXPIRY
-
-
-class InvalidVisitorPass(Exception):
-    pass
 
 
 class Visitor(models.Model):
     """A temporary visitor (betwixt anonymous and authenticated)."""
 
     DEFAULT_TOKEN_EXPIRY = datetime.timedelta(seconds=VISITOR_TOKEN_EXPIRY)
+    DEFAULT_SELF_SERVICE_EMAIL = "anon@example.com"
 
     uuid = models.UUIDField(default=uuid.uuid4)
     first_name = models.CharField(max_length=150, blank=True)
@@ -57,7 +55,7 @@ class Visitor(models.Model):
         verbose_name_plural = "Visitor passes"
 
     def __str__(self) -> str:
-        return f"Visitor pass for {self.email} ({self.scope})"
+        return f"Visitor pass {self.id} (scope='{self.scope}')"
 
     def __repr__(self) -> str:
         return (

--- a/visitors/models.py
+++ b/visitors/models.py
@@ -32,7 +32,7 @@ class Visitor(models.Model):
     DEFAULT_TOKEN_EXPIRY = datetime.timedelta(seconds=VISITOR_TOKEN_EXPIRY)
     DEFAULT_SELF_SERVICE_EMAIL = "anon@example.com"
 
-    uuid = models.UUIDField(default=uuid.uuid4)
+    uuid = models.UUIDField(default=uuid.uuid4, unique=True)
     first_name = models.CharField(max_length=150, blank=True)
     last_name = models.CharField(max_length=150, blank=True)
     email = models.EmailField(db_index=True)

--- a/visitors/signals.py
+++ b/visitors/signals.py
@@ -1,0 +1,6 @@
+from django.dispatch import Signal
+
+# sent when a user creates their own Visitor - can
+# be used to send the email with the token
+# kwargs: visitor
+self_service_visitor_created = Signal()

--- a/visitors/templates/visitors/self_service_request.html
+++ b/visitors/templates/visitors/self_service_request.html
@@ -1,0 +1,12 @@
+<html>
+    <body>
+        <div style="max-width: 800px">
+            <h1>Django Visitor Pass</h1>
+            <h2>Missing Template</h2>
+            <p>
+                If you are seeing this page, you are missing the "visitors/self_service_request.html"
+                template. You must provide your own template.
+            </p>
+        </div>
+    </body>
+</html>

--- a/visitors/templates/visitors/self_service_success.html
+++ b/visitors/templates/visitors/self_service_success.html
@@ -1,0 +1,12 @@
+<html>
+    <body>
+        <div style="max-width: 800px">
+            <h1>Django Visitor Pass</h1>
+            <h2>Missing Template</h2>
+            <p>
+                If you are seeing this page, you are missing the "visitors/self_service_success.html"
+                template. You must provide your own template.
+            </p>
+        </div>
+    </body>
+</html>

--- a/visitors/urls.py
+++ b/visitors/urls.py
@@ -1,0 +1,18 @@
+from django.urls import path
+
+from . import views
+
+app_name = "visitors"
+
+urlpatterns = [
+    path(
+        "self-service/<uuid:visitor_uuid>/",
+        views.SelfService.as_view(),
+        name="self-service",
+    ),
+    path(
+        "self-service/<uuid:visitor_uuid>/success/",
+        views.self_service_success,
+        name="self-service-success",
+    ),
+]

--- a/visitors/views.py
+++ b/visitors/views.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import uuid
+
+from django.http import HttpRequest, HttpResponse
+from django.http.response import HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
+from django.views import View
+
+from visitors.exceptions import InvalidVisitorPass
+
+from .forms import SelfServiceForm
+from .models import Visitor
+from .signals import self_service_visitor_created
+
+
+class SelfService(View):
+    """
+    Enable users to create their own visitor passes.
+
+    If a visitor pass is marked as `auto-enroll` then a user can
+    create their own pass. In this model, an user without access
+    would be redirected to this view, where they can input their
+    own name and email. They receive their own visitor pass.
+
+    The purpose of this is to add some protection to 'obscure'
+    urls. e.g. those that rely on an unguessable uuid - instead
+    of making those URLs completely public, we can force the user
+    to give us their name / email (name can be faked, but they
+    will require access to the email).
+
+    """
+
+    def get(self, request: HttpRequest, visitor_uuid: uuid.UUID) -> HttpResponse:
+        """Render the initial form."""
+        visitor = get_object_or_404(Visitor, uuid=visitor_uuid)
+        if visitor.is_active:
+            raise InvalidVisitorPass("Visitor pass has already been activated")
+        if visitor.has_expired:
+            raise InvalidVisitorPass("Visitor pass has expired")
+        form = SelfServiceForm(initial={"vuid": visitor.uuid})
+        return render(
+            request,
+            template_name="visitors/self_service_request.html",
+            context={"visitor": visitor, "form": form},
+        )
+
+    def post(self, request: HttpRequest, visitor_uuid: uuid.UUID) -> HttpResponse:
+        """
+        Process the form and send the pass email.
+
+        The core function here is to update the visitor object with
+        the details from the form. Once that is done the visitor
+        pass is active and can be sent to the user. This view fires
+        the `self_service_visitor_created` signal - you should use
+        this to send out the notification.
+
+        """
+        visitor = get_object_or_404(Visitor, uuid=visitor_uuid)
+        form = SelfServiceForm(request.POST)
+        if form.is_valid():
+            visitor.first_name = form.cleaned_data["first_name"]
+            visitor.last_name = form.cleaned_data["last_name"]
+            visitor.email = form.cleaned_data["email"]
+            visitor.reactivate()
+            # hook into this to send the email notification to the user.
+            self_service_visitor_created.send(sender=self.__class__, visitor=visitor)
+            url = reverse(
+                "visitors:self-service-success",
+                kwargs={"visitor_uuid": visitor_uuid},
+            )
+            return HttpResponseRedirect(url)
+        return render(
+            request,
+            template_name="visitors/self_service_request.html",
+            context={
+                "visitor": visitor,
+                "form": form,
+            },
+        )
+
+
+def self_service_success(request: HttpRequest, visitor_uuid: uuid.UUID) -> HttpResponse:
+    """Display the success page."""
+    visitor = get_object_or_404(Visitor, uuid=visitor_uuid)
+    return render(
+        request,
+        template_name="visitors/self_service_success.html",
+        context={"visitor": visitor},
+    )


### PR DESCRIPTION
This PR adds support for "self-service" visitor passes. This is a specific use case where you want to share a URL, but you don't know the contact details of the user with whom you want to share it in advance. The standard model for visitor passes is that you generate a pass for a user and then send them a unique link. If you want something that is more like a public URL, but you also want some control over its use, self-service is an option. In this use case the view is decorated, but instead of bumping the user with a 403, they are redirected to a form that asks them for their contact details, sends them a visitor pass link with the appropriate scope.