### PR TITLE
Refactor views to make them easier to override

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,6 @@
 [run]
+branch = true
 omit =
-    visitors/migrations/*.py
+    tests/*
+    */migrations/*.py
     .venv/*

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,8 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.9]
-        django: [31,32,main]
+        python: [3.8,3.9,"3.10"]
+        django: [31,32,40,main]
 
     env:
       TOXENV: py${{ matrix.python }}-django${{ matrix.django }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .coverage
 .tox
 .venv
+demo.db
 node_modules
 poetry.lock
 test.db

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,25 @@
 repos:
   # python import sorting - will amend files
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.9.2
+    rev: v5.10.1
     hooks:
       - id: isort
 
   # python code formatting - will amend files
   - repo: https://github.com/ambv/black
-    rev: 21.7b0
+    rev: 22.6.0
     hooks:
       - id: black
 
   # update syntax where appropriate
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.23.0
+    rev: v2.34.0
     hooks:
       - id: pyupgrade
 
   # formatting of django templates
   - repo: https://github.com/rtts/djhtml
-    rev: v1.4.9
+    rev: v1.5.1
     hooks:
       - id: djhtml
 
@@ -35,7 +35,7 @@ repos:
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.961
     hooks:
       - id: mypy
         args:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Django app for managing temporary session-based users.
 
+### Support
+
+This project currently supports Python 3.8+, Django 3.1+.
+
 ### Background
 
 This package has been extracted out of `django-request-token` as a specific use
@@ -87,7 +91,7 @@ objects. The user has a boolean `user.is_visitor` property, and the request has
 a `request.visitor` property which is the relevant `Visitor` object.
 
 This is done via two bits of middleware, `VisitorRequestMiddleware` and
-`VisitSessionMiddleware`. 
+`VisitSessionMiddleware`.
 
 #### `VisitorRequestMiddleware`
 
@@ -104,7 +108,7 @@ if it can't access `request.visitor`). It has two responsibilities:
 
 1. If the request object has a visitor object on it, then it _must_ have been
    set by the request middleware on the current request - so it's a new visitor,
-   and we immediately stash it in the `request.session`. 
+   and we immediately stash it in the `request.session`.
 
 1. If `request.visitor` is None, then we don't have a _new_ visitor, but there
    may be one already stashed in the `request.session`, in which case we want to

--- a/demo/templates/bar.html
+++ b/demo/templates/bar.html
@@ -17,34 +17,34 @@
     </head>
     <body>
         <p><a href="{% url 'index' %}"">Home</a></p>
-        <p>Hello, {{ visitor.first_name }}.</p>
-        <p>
+            <p>Hello, {{ visitor.first_name }}.</p>
+            <p>
             If you are seeing this page, you have successfully "self-served" and have visitor access
-            to this page.
-        </p>
-        <p>The details of your visitor pass are as follows:</p>
-        <dl>
-            <dt>First name:</dt>
-            <dd>{{ visitor.first_name }}</dd>
-            <dt>Last name:</dt>
-            <dd>{{ visitor.last_name }}</dd>
-            <dt>Email:</dt>
-            <dd>{{ visitor.email }}</dd>
-            <dt>Scope:</dt>
-            <dd>{{ visitor.scope }}</dd>
-            <dt>Created:</dt>
-            <dd>{{ visitor.created_at }}</dd>
-            <dt>Expires at:</dt>
-            <dd>{{ visitor.expires_at }}</dd>
-            <dt>Has expired:</dt>
-            <dd>{{ visitor.has_expired }}</dd>
-            <dt>Is active:</dt>
-            <dd>{{ visitor.is_active }}</dd>
-            <dt>Is valid:</dt>
-            <dd>{{ visitor.is_valid }}</dd>
-        </dl>
-        <p>Now that you are 'authenticated' as a visitor, you can refresh the page
-            without the `vuid=` querystring param. To refresh the page, click <a href="{% url 'bar' %}">here</a>.</p>
-        <p>To deactivate your visitor token, click <a href="{% url 'logout' %}">here</a>.</p>
-    </body>
-</html>
+                to this page.
+                </p>
+                <p>The details of your visitor pass are as follows:</p>
+                <dl>
+                <dt>First name:</dt>
+                <dd>{{ visitor.first_name }}</dd>
+                <dt>Last name:</dt>
+                <dd>{{ visitor.last_name }}</dd>
+                <dt>Email:</dt>
+                <dd>{{ visitor.email }}</dd>
+                <dt>Scope:</dt>
+                <dd>{{ visitor.scope }}</dd>
+                <dt>Created:</dt>
+                <dd>{{ visitor.created_at }}</dd>
+                <dt>Expires at:</dt>
+                <dd>{{ visitor.expires_at }}</dd>
+                <dt>Has expired:</dt>
+                <dd>{{ visitor.has_expired }}</dd>
+                <dt>Is active:</dt>
+                <dd>{{ visitor.is_active }}</dd>
+                <dt>Is valid:</dt>
+                <dd>{{ visitor.is_valid }}</dd>
+                </dl>
+                <p>Now that you are 'authenticated' as a visitor, you can refresh the page
+                without the `vuid=` querystring param. To refresh the page, click <a href="{% url 'bar' %}">here</a>.</p>
+                    <p>To deactivate your visitor token, click <a href="{% url 'logout' %}">here</a>.</p>
+                        </body>
+                        </html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-visitor-pass"
-version = "0.5.2"
+version = "0.6"
 description = "Django app for managing temporary session-based users."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -15,18 +15,19 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
 ]
 packages = [{ include = "visitors" }]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-django = "^3.0 || ^4.0"
+django = "^3.1 || ^4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = fmt, lint, mypy, checks, py{3.8,3.9}-django{31,32,main}
+envlist = fmt, lint, mypy, checks, py{3.8,3.9,3.10}-django{31,32,40,main}
 
 [testenv]
 deps =
@@ -10,6 +10,7 @@ deps =
     pytest-django
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
     djangomaster: https://github.com/django/django/archive/main.tar.gz
 
 commands =

--- a/visitors/urls.py
+++ b/visitors/urls.py
@@ -7,12 +7,12 @@ app_name = "visitors"
 urlpatterns = [
     path(
         "self-service/<uuid:visitor_uuid>/",
-        views.SelfService.as_view(),
+        views.SelfServiceRequest.as_view(),
         name="self-service",
     ),
     path(
         "self-service/<uuid:visitor_uuid>/success/",
-        views.self_service_success,
+        views.SelfServiceSuccess.as_view(),
         name="self-service-success",
     ),
 ]


### PR DESCRIPTION
The current implementation has a single fixed template for the visitor
request / success pages, and real-world use has shown that this may not
be flexible enough. This PR updates the way that the views work to
enable subclasses to have full control over the templates / contexts
that they use. This means you can have different templates for different
use cases.