### PR TITLE
Misc: Add support for django 5.2

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install and run tox
         run: |
@@ -45,10 +45,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install and run tox
         run: |
@@ -60,24 +60,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
         # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
+        django: ["42", "50", "52", "main"]
         exclude:
-          - python: "3.8"
-            django: "50"
-          - python: "3.8"
-            django: "main"
-          - python: "3.9"
-            django: "50"
-          - python: "3.9"
-            django: "main"
           - python: "3.10"
             django: "main"
           - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
+            django: "main"
+          - python: "3.13"
+            django: "42"
+          - python: "3.13"
+            django: "50"
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,21 @@
 repos:
   # python code formatting - will amend files
-  - repo: https://github.com/ambv/black
-    rev: 23.10.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.11.13"
     hooks:
-      - id: black
+      - id: ruff-format
+        args: [format]
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.1.4"
+    rev: "v0.11.13"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.6.1
+    rev: v1.16.0
     hooks:
       - id: mypy
         args:

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,7 @@
 line-length = 88
+indent-width = 4
+
+[lint]
 ignore = [
     "D100",  # Missing docstring in public module
     "D101",  # Missing docstring in public class
@@ -19,7 +22,6 @@ ignore = [
     "D411",  # Missing blank line before section
     "D412",  # No blank lines allowed between a section header and its content
     "D416",  # Section name should end with a colon
-    "D417",
     "D417",  # Missing argument description in the docstring
 ]
 select = [
@@ -34,13 +36,13 @@ select = [
     "W",  # pycodestype (warnings)
 ]
 
-[isort]
+[lint.isort]
 combine-as-imports = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 8
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "*tests/*" = [
     "D205",  # 1 blank line required between summary line and description
     "D400",  # First line should end with a period

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.1
+
+* Add support for Django 5.2
+* Add support for Python 3.13
+* Drop support for Django versions before 4.2
+* Drop support for Python 3.8 and 3.9
+* Update ruff commands to use modern syntax
+* Update GitHub Actions to only test Django main branch with Python 3.12 and 3.13
+* Drop `black` in favor for `ruff`
+
 ## v1.0
 
 * Add support for Django 5.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django app for managing temporary session-based users.
 
 ### Support
 
-This project currently supports Python 3.8+, Django 3.2+.
+This project currently supports Python 3.10+, Django 4.2+.
 
 ### Background
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-visitor-pass"
-version = "1.0"
+version = "1.1"
 description = "Django app for managing temporary session-based users."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -13,28 +13,24 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "visitors" }]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-django = "^3.2 || ^4.0 || ^5.0"
+python = "^3.10"
+django = "^4.2 || ^5.0 || ^5.2"
 
 [tool.poetry.dev-dependencies]
-black = "*"
 coverage = "*"
 mypy = "*"
 pre-commit = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,11 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{38,39,310}
-    django40-py{38,39,310}
-    django41-py{38,39,310,311}
-    django42-py{38,39,310,311}
+    ; https://docs.djangoproject.com/en/5.2/releases/
+    django42-py{310,311,312}
     django50-py{310,311,312}
-    djangomain-py{311,312}
+    django52-py{310,311,312,313}
+    djangomain-py{312,313}
 
 [testenv]
 deps =
@@ -17,11 +15,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django52: Django>=5.2,<5.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =
@@ -35,12 +31,12 @@ commands =
     python manage.py makemigrations --dry-run --check --verbosity 3
 
 [testenv:fmt]
-description = Python source code formatting (black)
+description = Python source code formatting (ruff)
 deps =
-    black
+    ruff
 
 commands =
-    black --check visitors
+    ruff format visitors
 
 [testenv:lint]
 description = Python source code linting (ruff)
@@ -48,7 +44,7 @@ deps =
     ruff
 
 commands =
-    ruff visitors
+    ruff check --fix visitors
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
## 🚀 Add Django 5.2 Support + Development Tooling

This PR modernises the package by adding Django 5.2 support while deprecating older versions and updating the development toolchain.

### 🔄 Django Version Support Changes
- **Added** support for Django 5.2
- **Dropped** support for Django versions before 4.2 (3.2)
- **Added** support for Python 3.13
- **Dropped** support for Python 3.8 and 3.9
- **Updated** documentation to reflect new version requirements

### 🛠️ Development Tools Modernization  
- **Replaced** Black with Ruff for code formatting across the entire toolchain
- **Updated** Ruff to v0.11.13 in pre-commit hooks
- **Modernised** ruff commands to use `ruff check --fix` and `ruff format` syntax
- **Updated** ruff configuration to use modern `[lint]` section format
- **Updated** Mypy to v1.16.0 in pre-commit hooks

### 🧪 CI/CD Improvements
- **Restricted** Django main branch testing to Python 3.12 and 3.13 only
- **Updated** tox configuration with proper Django version constraints
- **Removed** outdated test combinations from CI matrix

### 📦 Version Bump
- **Bumped** package version from 1.0 to 1.1