### PR TITLE
Misc: Django 6.0 upgrades

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -60,18 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.12", "3.13"]
         # build LTS version, next version, HEAD
-        django: ["42", "50", "52", "main"]
-        exclude:
-          - python: "3.10"
-            django: "main"
-          - python: "3.11"
-            django: "main"
-          - python: "3.13"
-            django: "42"
-          - python: "3.13"
-            django: "50"
+        django: ["52", "60", "main"]
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django app for managing temporary session-based users.
 
 ### Support
 
-This project currently supports Python 3.10+, Django 4.2+.
+This project currently supports Python 3.12+ and Django 5.2-6.0.
 
 ### Background
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-visitor-pass"
-version = "1.1"
+version = "1.2"
 description = "Django app for managing temporary session-based users."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -13,24 +13,21 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "visitors" }]
 
 [tool.poetry.dependencies]
-python = "^3.10"
-django = "^4.2 || ^5.0 || ^5.2"
+python = "^3.12"
+django = ">=5.2,<7.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 coverage = "*"
 mypy = "*"
 pre-commit = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,9 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.2/releases/
-    django42-py{310,311,312}
-    django50-py{310,311,312}
-    django52-py{310,311,312,313}
+    ; https://docs.djangoproject.com/en/6.0/releases/
+    django52-py{312,313}
+    django60-py{312,313}
     djangomain-py{312,313}
 
 [testenv]
@@ -15,9 +14,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
## Summary

This PR upgrades the package to support Django 6.0 and Python 3.13.

## Changes

### Added
  - ✅ Django 6.0 support
  - ✅ Python 3.12, 3.13 support

### Removed
  - ❌ Python 3.9, 3.10, 3.11 support (now requires Python 3.12+)
  - ❌ Django 4.2 and 5.0 support (now supports Django 5.2-6.0)